### PR TITLE
role.teamSanta.nameの重複と見易さの修正

### DIFF
--- a/Nebula/Resources/Lang.dat
+++ b/Nebula/Resources/Lang.dat
@@ -804,6 +804,7 @@
 "role.opportunist.task.staying.decontamination" : "The Decontamination"
 
 "role.teamSanta.name" : "Team Santa"
+"role.teamSanta.info" : "You were welcomed into Team Santa.\nWork together for victory."
 
 "role.santaClaus.name" : "Santa Claus"
 "role.santaClaus.short" : "SC"
@@ -891,7 +892,6 @@
 "role.avengerTarget.info" : "You killed one of lovers.\nThe other of them may take the chance to kill you."
 
 "role.teamSanta.name" : "Team Santa"
-"role.teamSanta.info" : "You were welcomed into Team Santa.\nWork together for victory."
 
 "role.investigator.name" : "Investigator"
 "role.investigator.short" : "I"


### PR DESCRIPTION
見易さと重複がある為、編集

"role.teamSanta.name" : "Team Santa" を 806行目と893行目で二度記載されているので、893行目を削除。
894行目の"role.teamSanta.info" : "You were welcomed into Team Santa.\nWork together for victory."を806行目の"role.teamSanta.name"下に移動。