### PR TITLE
Extreme Skinsの出力構造周りをExtreme Skins.Coreにリファクタ

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ExtremeSkins.Core"]
+	path = ExtremeSkins.Core
+	url = https://github.com/yukieiji/ExtremeSkins.Core.git

--- a/Nebula/Module/DesignerTool.cs
+++ b/Nebula/Module/DesignerTool.cs
@@ -1,6 +1,7 @@
 ﻿using Nebula.Expansion;
 using ExtremeSkins.Core;
 using ExtremeSkins.Core.ExtremeHats;
+using ExtremeSkins.Core.ExtremeVisor;
 using System.Security.Cryptography;
 using System.Text;
 using UnityEngine.Events;
@@ -10,6 +11,7 @@ using static Nebula.Module.CustomParts;
 using static Rewired.Controller;
 
 using ExHData = ExtremeSkins.Core.ExtremeHats.DataStructure;
+using ExVData = ExtremeSkins.Core.ExtremeVisor.DataStructure;
 
 namespace Nebula.Module;
 
@@ -325,13 +327,13 @@ public static class DesignersSaver
             translationDic[name] = hat.Name.Value;
             translationDic[authorName] = hat.Author.Value;
 
-            string exportFolder = Path.Combine(globalExportFolder, ExHData.FolderName, name);
+            string exportHatFolder = Path.Combine(globalExportFolder, ExHData.FolderName, name);
 
-            CopyFile(hatCategory, hat.I_Main, Path.Combine(exportFolder, ExHData.FrontImageName));
-            if (hat.I_Flip) CopyFile(hatCategory, hat.I_Flip, Path.Combine(exportFolder, ExHData.FrontFlipImageName));
-            if (hat.I_Back) CopyFile(hatCategory, hat.I_Back, Path.Combine(exportFolder, ExHData.BackImageName));
-            if (hat.I_BackFlip) CopyFile(hatCategory, hat.I_BackFlip, Path.Combine(exportFolder, ExHData.BackFlipImageName));
-            if (hat.I_Climb) CopyFile(hatCategory, hat.I_Climb, Path.Combine(exportFolder, ExHData.ClimbImageName));
+            CopyFile(hatCategory, hat.I_Main, Path.Combine(exportHatFolder, ExHData.FrontImageName));
+            if (hat.I_Flip) CopyFile(hatCategory, hat.I_Flip, Path.Combine(exportHatFolder, ExHData.FrontFlipImageName));
+            if (hat.I_Back) CopyFile(hatCategory, hat.I_Back, Path.Combine(exportHatFolder, ExHData.BackImageName));
+            if (hat.I_BackFlip) CopyFile(hatCategory, hat.I_BackFlip, Path.Combine(exportHatFolder, ExHData.BackFlipImageName));
+            if (hat.I_Climb) CopyFile(hatCategory, hat.I_Climb, Path.Combine(exportHatFolder, ExHData.ClimbImageName));
 
             HatInfo hatInfo = new(
                 Name: name,
@@ -343,34 +345,35 @@ public static class DesignersSaver
                 Back: hat.I_Back,
                 BackFlip: hat.I_BackFlip
             );
-            InfoBase.ExportToJson(hatInfo, exportFolder);
+            InfoBase.ExportToJson(hatInfo, exportHatFolder);
         }
 
+        const string visorCategory = "visors";
         var visors = CustomParts.CustomVisorRegistry.Values.Where((c) => c.IsLocal).ToArray();
         foreach (var visor in visors)
         {
             //メイン画像が無いあるいはアニメーションバイザーの場合はスルー
             if (!visor.I_Main) continue;
             if (visor.Contents().Any((v) => v is CustomVImage image && image.Length > 1)) continue;
-            json = new();
-            var content = json.RootContent;
+
             string name = ConvertName(visor.Author.Value + visor.Name.Value);
             string authorName = ConvertName(visor.Author.Value);
             translationDic[name] = visor.Name.Value;
             translationDic[authorName] = visor.Author.Value;
 
-            content.AddContent("LeftIdle", new JsonBooleanContent(visor.I_Flip));
-            content.AddContent("Shader", new JsonBooleanContent(visor.Adaptive.Value));
-            content.AddContent("BehindHat", new JsonBooleanContent(visor.BehindHat.Value));
-            content.AddContent("ComitHash", new JsonStringContent(""));
-            content.AddContent("Name", new JsonStringContent(visor.Name.Value));
-            content.AddContent("Author", new JsonStringContent(visor.Author.Value));
-            CopyFile("visors", visor.I_Main, "GlobalCosmicExR/ExtremeVisor/" + name + "/idle.png");
-            if (visor.I_Flip) CopyFile("visors", visor.I_Flip, "GlobalCosmicExR/ExtremeVisor/" + name + "/flip_idle.png");
+            string exportVisorFolder = Path.Combine(globalExportFolder, ExHData.FolderName, name);
 
-            stream = new StreamWriter(File.Create("GlobalCosmicExR/ExtremeVisor/" + name + "/info.json"));
-            stream.Write(json.Generate());
-            stream.Close();
+            CopyFile(visorCategory, visor.I_Main, Path.Combine(exportVisorFolder, ExVData.IdleImageName));
+            if (visor.I_Flip) CopyFile(visorCategory, visor.I_Flip, Path.Combine(exportVisorFolder, ExVData.FlipIdleImageName));
+
+            VisorInfo visorInfo = new(
+                Name: visor.Name.Value,
+                Author: visor.Name.Value,
+                LeftIdle: visor.I_Flip,
+                Shader: visor.Adaptive.Value,
+                BehindHat: visor.BehindHat.Value
+            );
+            InfoBase.ExportToJson(visorInfo, exportVisorFolder);
         }
 
         if (translationDic.Count == 0) return;

--- a/Nebula/Module/DesignerTool.cs
+++ b/Nebula/Module/DesignerTool.cs
@@ -377,11 +377,10 @@ public static class DesignersSaver
         }
 
         if (translationDic.Count == 0) return;
-        Directory.CreateDirectory("GlobalCosmicExR/CreatorMode");
-        stream = new StreamWriter(File.Create("GlobalCosmicExR/CreatorMode/translation.csv"));
-        stream.WriteLine("TransKey,English,Latam,Brazilian,Portuguese,Korean,Russian,Dutch,Filipino,French,German,Italian,Japanese,Spanish,SChinese,TChinese,Irish");
-        foreach (var entry in translationDic) stream.WriteLine($"{entry.Key},,,,,,,,,,,,{entry.Value},,,,,");
-        stream.Close();
+        using (var stream = CreatorMode.CreateTranslationWriter(globalExportFolder))
+        {
+            foreach (var entry in translationDic) stream.WriteLine($"{entry.Key},,,,,,,,,,,,{entry.Value},,,,,");
+        }
 
         //ネームプレートは作れないのでひとまずスルー
         /*

--- a/Nebula/NebulaPlugin.csproj
+++ b/Nebula/NebulaPlugin.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\Config.cs" Link="ExtremeSkins.Core\Config.cs" />
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\CreatorMode.cs" Link="ExtremeSkins.Core\CreatorMode.cs" />
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\InfoBase.cs" Link="ExtremeSkins.Core\InfoBase.cs" />
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeHats\HatInfo.cs" Link="ExtremeSkins.Core\ExtremeHats\HatInfo.cs" />

--- a/Nebula/NebulaPlugin.csproj
+++ b/Nebula/NebulaPlugin.csproj
@@ -49,6 +49,12 @@
     <Reference Include="..\..\Among Us\BepInEx\core\*.dll" />
     <Reference Include="..\..\Among Us\BepInEx\interop\*.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\CreatorMode.cs" Link="ExtremeSkins.Core\CreatorMode.cs" />
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\InfoBase.cs" Link="ExtremeSkins.Core\InfoBase.cs" />
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeHats\HatInfo.cs" Link="ExtremeSkins.Core\ExtremeHats\HatInfo.cs" />
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeHats\DataStructure.cs" Link="ExtremeSkins.Core\ExtremeHats\DataStructure.cs" />
+  </ItemGroup>
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
     <Message Text="Second occurrence" />

--- a/Nebula/NebulaPlugin.csproj
+++ b/Nebula/NebulaPlugin.csproj
@@ -49,11 +49,14 @@
     <Reference Include="..\..\Among Us\BepInEx\core\*.dll" />
     <Reference Include="..\..\Among Us\BepInEx\interop\*.dll" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\CreatorMode.cs" Link="ExtremeSkins.Core\CreatorMode.cs" />
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\InfoBase.cs" Link="ExtremeSkins.Core\InfoBase.cs" />
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeHats\HatInfo.cs" Link="ExtremeSkins.Core\ExtremeHats\HatInfo.cs" />
     <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeHats\DataStructure.cs" Link="ExtremeSkins.Core\ExtremeHats\DataStructure.cs" />
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeVisor\VisorInfo.cs" Link="ExtremeSkins.Core\ExtremeVisor\VisorInfo.cs" />
+    <Compile Include="..\ExtremeSkins.Core\ExtremeSkins.Core\ExtremeVisor\DataStructure.cs" Link="ExtremeSkins.Core\ExtremeVisor\DataStructure.cs" />
   </ItemGroup>
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">


### PR DESCRIPTION
- 変更箇所
  - Extreme Skinsへの出力を行っている箇所を[Extreme Skins.Core](https://github.com/yukieiji/ExtremeSkins.Core)へのコードに変更
    - この変更によってSkins等に何らかの変更等があってもサブモジュールの更新だけで対応できるようになります
  - 一部リファクタを行いハードコーディングが減りました(Path.Combineを使うことで環境周りの不具合もでなくなります)

- 不具合修正箇所
  - CreatorModeの翻訳csvは[UTF-8で読み込みを行っている](https://github.com/yukieiji/ExtremeRoles/blob/ce6d03bc8933d871eb1a1083e0691fbc24482807/ExtremeSkins/CreatorModeManager.cs#L96-L97)ので文字コーディング周りの不具合が出なくなったはずです